### PR TITLE
Fix scan results output file

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -43,7 +43,7 @@ public class ScannerExecuter {
 				args.addTokenized(runOptions);
 				if (version.trim().equals("2.x")) {
 					args.add("--rm", aquaScannerImage, "--user", user, "--password", password, "--host", apiURL,
-							"--registry", registry, "--image", hostedImage, "--html");
+							"--registry", registry, "--image", hostedImage, "--htmlfile scanout.html");
 					if (timeout > 0) { // 0 means use default
 						args.add("--timeout", String.valueOf(timeout));
 					}
@@ -52,7 +52,7 @@ public class ScannerExecuter {
 				} else if (version.trim().equals("3.x")) {
 					args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "scan",
 							"--user", user, "--password", password, "--host", apiURL, "--registry", registry,
-							hostedImage, "--html");
+							hostedImage, "--htmlfile scanout.html");
 					passwordIndex = 10;
 				}
 
@@ -65,11 +65,11 @@ public class ScannerExecuter {
 				args.addTokenized(runOptions);
 				if (version.trim().equals("2.x")) {
 					args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "--user",
-							user, "--password", password, "--host", apiURL, "--local", "--image", localImage, "--html");
+							user, "--password", password, "--host", apiURL, "--local", "--image", localImage, "--htmlfile scanout.html");
 					passwordIndex = 9;
 				} else if (version.trim().equals("3.x")) {
 					args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "scan",
-							"--user", user, "--password", password, "--host", apiURL, "--local", localImage, "--html");
+							"--user", user, "--password", password, "--host", apiURL, "--local", localImage, "--htmlfile scanout.html");
 					passwordIndex = 10;
 				}
 

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -43,7 +43,7 @@ public class ScannerExecuter {
 				args.addTokenized(runOptions);
 				if (version.trim().equals("2.x")) {
 					args.add("--rm", aquaScannerImage, "--user", user, "--password", password, "--host", apiURL,
-							"--registry", registry, "--image", hostedImage, "--htmlfile scanout.html");
+							"--registry", registry, "--image", hostedImage, "--htmlfile", artifactName);
 					if (timeout > 0) { // 0 means use default
 						args.add("--timeout", String.valueOf(timeout));
 					}
@@ -52,7 +52,7 @@ public class ScannerExecuter {
 				} else if (version.trim().equals("3.x")) {
 					args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "scan",
 							"--user", user, "--password", password, "--host", apiURL, "--registry", registry,
-							hostedImage, "--htmlfile scanout.html");
+							hostedImage, "--htmlfile", artifactName);
 					passwordIndex = 10;
 				}
 
@@ -65,11 +65,11 @@ public class ScannerExecuter {
 				args.addTokenized(runOptions);
 				if (version.trim().equals("2.x")) {
 					args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "--user",
-							user, "--password", password, "--host", apiURL, "--local", "--image", localImage, "--htmlfile scanout.html");
+							user, "--password", password, "--host", apiURL, "--local", "--image", localImage, "--htmlfile", artifactName);
 					passwordIndex = 9;
 				} else if (version.trim().equals("3.x")) {
 					args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "scan",
-							"--user", user, "--password", password, "--host", apiURL, "--local", localImage, "--htmlfile scanout.html");
+							"--user", user, "--password", password, "--host", apiURL, "--local", localImage, "--htmlfile", artifactName);
 					passwordIndex = 10;
 				}
 


### PR DESCRIPTION
Currently, the plugin offers to view the results at "scanout.hmtl" but the docker run command isn't writing the output to any file. This pull request fixes that.