### PR TITLE
Revert "Fix scan results output file"

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -43,7 +43,7 @@ public class ScannerExecuter {
 				args.addTokenized(runOptions);
 				if (version.trim().equals("2.x")) {
 					args.add("--rm", aquaScannerImage, "--user", user, "--password", password, "--host", apiURL,
-							"--registry", registry, "--image", hostedImage, "--htmlfile", artifactName);
+							"--registry", registry, "--image", hostedImage, "--html");
 					if (timeout > 0) { // 0 means use default
 						args.add("--timeout", String.valueOf(timeout));
 					}
@@ -52,7 +52,7 @@ public class ScannerExecuter {
 				} else if (version.trim().equals("3.x")) {
 					args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "scan",
 							"--user", user, "--password", password, "--host", apiURL, "--registry", registry,
-							hostedImage, "--htmlfile", artifactName);
+							hostedImage, "--html");
 					passwordIndex = 10;
 				}
 
@@ -65,11 +65,11 @@ public class ScannerExecuter {
 				args.addTokenized(runOptions);
 				if (version.trim().equals("2.x")) {
 					args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "--user",
-							user, "--password", password, "--host", apiURL, "--local", "--image", localImage, "--htmlfile", artifactName);
+							user, "--password", password, "--host", apiURL, "--local", "--image", localImage, "--html");
 					passwordIndex = 9;
 				} else if (version.trim().equals("3.x")) {
 					args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "scan",
-							"--user", user, "--password", password, "--host", apiURL, "--local", localImage, "--htmlfile", artifactName);
+							"--user", user, "--password", password, "--host", apiURL, "--local", localImage, "--html");
 					passwordIndex = 10;
 				}
 


### PR DESCRIPTION
Reverts jenkinsci/aqua-security-scanner-plugin#4

the output is to the stdout. it allow us to display the report on a dedicated "Aqua Security Scanner" report section that displaying the HTML.

Your pull request broke this functionality.