### PR TITLE
Fixing a race condition while generating HTML

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -166,6 +166,8 @@ public class ScannerExecuter {
 		listener.getLogger().println(scanOutput.substring(0,htmlStart));
 		int htmlEnd = scanOutput.lastIndexOf("</html>") + 7;
 		scanOutput = scanOutput.substring(htmlStart,htmlEnd);
+		String scanRegex = "(?m)\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01]).*";
+		scanOutput = scanOutput.replaceAll(scanRegex, "");
 		try
 		{
 			target.write(scanOutput, "UTF-8");


### PR DESCRIPTION
The regex will match the timestamps generated by the scanner stdout log and will skip them from adding to the scan report HTML code.

The race condition issue is not with the Jenkins plugin but with the scanner itself. I have tried to execute the scanner manually and observed that **Deregistering from console** message is printed in between the html code.

@oranmoshai  @eranbibi 
Please approve.