### PR TITLE
Add docker-archive feature

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
@@ -49,6 +49,7 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 	private final boolean showNegligible;
 	private final String policies;
 	private final String customFlags;
+	private final String tarFilePath;
 
 	private static int count;
 	private static int buildId = 0;
@@ -65,7 +66,8 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 	// "DataBoundConstructor"
 	@DataBoundConstructor
 	public AquaDockerScannerBuilder(String locationType, String registry, boolean register, String localImage, String hostedImage,
-			String onDisallowed, String notCompliesCmd,  boolean hideBase, boolean showNegligible, String policies, String customFlags) {
+			String onDisallowed, String notCompliesCmd,  boolean hideBase, boolean showNegligible, String policies,
+			String customFlags,	String tarFilePath) {
 		this.locationType = locationType;
 		this.registry = registry;
 		this.register = register;
@@ -77,6 +79,7 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 		this.showNegligible = showNegligible;
 		this.policies = policies;
 		this.customFlags = customFlags;
+		this.tarFilePath = tarFilePath;
 	}
 
 	/**
@@ -131,6 +134,8 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 		return showNegligible;
 	}
 
+	public String getTarFilePath() { return tarFilePath; }
+
 	// Returns the 'checked' state of the radio button for the step GUI
 	public String isLocationType(String type) {
 		if (this.locationType == null) {
@@ -150,7 +155,6 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 			return this.onDisallowed.equals(state) ? "true" : "false";
 		}
 	}
-
 
 	@Override
 	public void perform(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener)
@@ -192,7 +196,8 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 
 		int exitCode = ScannerExecuter.execute(build, workspace,launcher, listener, artifactName, aquaScannerImage, apiURL, user,
 				password, version, timeout, runOptions, locationType, localImage, registry, register, hostedImage, hideBase,
-				showNegligible, onDisallowed == null || !onDisallowed.equals("fail"), notCompliesCmd, caCertificates, policies, customFlags);
+				showNegligible, onDisallowed == null || !onDisallowed.equals("fail"), notCompliesCmd, caCertificates,
+				policies, customFlags, tarFilePath);
 		build.addAction(new AquaScannerAction(build, artifactSuffix, artifactName));
 
 		archiveArtifacts(build, workspace, launcher, listener);

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -15,6 +15,9 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.Secret;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 /**
  * This class does the actual execution..
  *
@@ -25,7 +28,8 @@ public class ScannerExecuter {
 	public static int execute(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener, String artifactName,
 			String aquaScannerImage, String apiURL, String user, Secret password, String version, int timeout,
 			String runOptions, String locationType, String localImage, String registry, boolean register, String hostedImage,
-			boolean hideBase, boolean showNegligible, boolean checkonly, String notCompliesCmd, boolean caCertificates, String policies, String customFlags) {
+			boolean hideBase, boolean showNegligible, boolean checkonly, String notCompliesCmd, boolean caCertificates,
+			String policies, String customFlags, String tarFilePath) {
 
 		PrintStream print_stream = null;
 		try {
@@ -35,6 +39,12 @@ public class ScannerExecuter {
 			localImage = env.expand(localImage);
 			registry = env.expand(registry);
 			hostedImage = env.expand(hostedImage);
+			tarFilePath = env.expand(tarFilePath);
+
+			// extract file name from path for scan tagging
+			Path path = Paths.get(tarFilePath);
+			Path fileName = path.getFileName();
+			String imgName = fileName.toString().split("\\.")[0];
 
 			ArgumentListBuilder args = new ArgumentListBuilder();
 			args.add("docker", "run");
@@ -76,6 +86,12 @@ public class ScannerExecuter {
 				if (register) {
 					args.add("--registry", registry);
 					args.add("--register");
+				}
+				break;
+			case "dockerarchive":
+				args.addTokenized(runOptions);
+				if (version.trim().equals("3.x")) {
+					args.add("--rm", "-v", tarFilePath+":"+tarFilePath, aquaScannerImage, "scan", imgName+":tar", "--host", apiURL, "--docker-archive", tarFilePath);
 				}
 				break;
 			default:

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
@@ -33,6 +33,11 @@
 		<f:checkbox name="hideBase"/>
       </f:entry>
    </f:radioBlock>
+   <f:radioBlock checked="${instance.isLocationType('dockerarchive')}" name="locationType" value="dockerarchive" title="docker-archive" inline="true" help="/plugin/aqua-security-scanner/help-isdockerarchive.html">
+     <f:entry title="Tar file path" field="tarFilePath">
+   	   <f:textbox />
+     </f:entry>
+   </f:radioBlock>
    <f:entry title="Show negligible vulnerabilities" field="showNegligible">
      <f:checkbox name="showNegligible"/>
    </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-tarfilepath.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-tarfilepath.html
@@ -1,0 +1,3 @@
+<div>
+Should provide the relative path of tar file to scan.
+</div>

--- a/src/main/webapp/help-isdockerarchive.html
+++ b/src/main/webapp/help-isdockerarchive.html
@@ -1,0 +1,3 @@
+<div>
+Scan docker-archive files which is in tar file format. Provide tar file relative path to scan . E.g. <i>docker save -o path image_name</i>
+</div>


### PR DESCRIPTION
https://scalock.atlassian.net/browse/SLK-24038

Support the new 'docker-archive' flag to enable local scanning without the need to mount the docker.sock file

Updated plugin with 

- Docker-archive option
- Tar file path to scan