### PR TITLE
Fix stapler logging error for missing field

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
@@ -159,7 +159,7 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 	}
 
 	@DataBoundSetter
-	public void setTatFilePath(@CheckForNull String tarFilePath) {
+	public void setTarFilePath(@CheckForNull String tarFilePath) {
 		this.tarFilePath = Util.fixNull(tarFilePath);
 	}
 


### PR DESCRIPTION
Because of this, `stapler` is logging a missing field, which is generating a lot of noises in the logs and potentially limiting the IO.