### PR TITLE
feature: Added 2 new textbox parameters for local Image scan to support custom container runtime.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
@@ -48,6 +48,8 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 	private final boolean showNegligible;
 	private final String policies;
 	private final String customFlags;
+	private final String containerRuntime;
+	private final String scannerPath;
 
 	@CheckForNull
 	private String tarFilePath;
@@ -68,7 +70,7 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 	@DataBoundConstructor
 	public AquaDockerScannerBuilder(String locationType, String registry, boolean register, String localImage, String hostedImage,
 			String onDisallowed, String notCompliesCmd,  boolean hideBase, boolean showNegligible, String policies,
-			String customFlags,	String tarFilePath) {
+			String customFlags,	String tarFilePath, String containerRuntime, String scannerPath) {
 		this.locationType = locationType;
 		this.registry = registry;
 		this.register = register;
@@ -81,6 +83,8 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 		this.policies = policies;
 		this.customFlags = customFlags;
 		this.tarFilePath = tarFilePath;
+		this.containerRuntime = containerRuntime;
+		this.scannerPath = scannerPath;
 	}
 
 	/**
@@ -89,6 +93,14 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 	 */
 	public String getLocationType() {
 		return locationType;
+	}
+
+	public String getContainerRuntime() {
+		return containerRuntime;
+	}
+
+	public String getScannerPath() {
+		return scannerPath;
 	}
 
 	public String getRegistry() {
@@ -204,7 +216,7 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 		int exitCode = ScannerExecuter.execute(build, workspace,launcher, listener, artifactName, aquaScannerImage, apiURL, user,
 				password, version, timeout, runOptions, locationType, localImage, registry, register, hostedImage, hideBase,
 				showNegligible, onDisallowed == null || !onDisallowed.equals("fail"), notCompliesCmd, caCertificates,
-				policies, customFlags, tarFilePath);
+				policies, customFlags, tarFilePath, containerRuntime, scannerPath);
 		build.addAction(new AquaScannerAction(build, artifactSuffix, artifactName));
 
 		archiveArtifacts(build, workspace, launcher, listener);

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -138,7 +138,8 @@ public class ScannerExecuter {
 			args.addMasked(password);
 
 			if (!containerRuntime.equals("docker")){
-				args.add("--code-scan", "/");
+				args.add("--image-name", localImage);
+				args.add("--fs-scan", "/");
 			}
 
 			File outFile = new File(build.getRootDir(), "out");

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -42,8 +42,10 @@ public class ScannerExecuter {
 
 			ArgumentListBuilder args = new ArgumentListBuilder();
 
+			boolean isDocker = false;
 			if(containerRuntime.equals("")) {
 				containerRuntime = "docker";
+				isDocker = true;
 			}
 			args.add(containerRuntime);
 			args.add("run");
@@ -77,19 +79,19 @@ public class ScannerExecuter {
 				}
 				break;
 			case "local":
-				if(!scannerPath.equals("") && !containerRuntime.equals("docker")) {
+				if(!scannerPath.equals("") && !isDocker) {
 					args.add("-v", scannerPath+":/aquasec/scannercli:Z", "--entrypoint=/aquasec/scannercli");
 				}
 				args.addTokenized(runOptions);
 				if (version.trim().equals("2.x")) {
-					if(containerRuntime.equals("docker")){
+					if(isDocker){
 						args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "--host", apiURL, "--local", "--image", localImage);
 					} else {
 						args.add("--rm", "-u", "root", localImage,"--host", apiURL, "--image");						
 					}
 					
 				} else if (version.trim().equals("3.x")) {
-					if(containerRuntime.equals("docker")){
+					if(isDocker){
 						args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "scan", "--host", apiURL, "--local", localImage);	
 					} else {
 						args.add("--rm", "-u", "root", localImage, "scan", "--host", apiURL);
@@ -137,7 +139,7 @@ public class ScannerExecuter {
 			args.add("--html", "--user", user, "--password");
 			args.addMasked(password);
 
-			if (!containerRuntime.equals("docker")){
+			if (!isDocker){
 				args.add("--image-name", localImage);
 				args.add("--fs-scan", "/");
 			}

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
@@ -24,6 +24,12 @@
     <f:entry title="Image name" field="localImage">
 	<f:textbox />
       </f:entry>
+    <f:entry title="Container Runtime" field="containerRuntime" help="/plugin/aqua-security-scanner/help-containerRuntime.html">
+      <f:textbox default="docker" /> 
+    </f:entry>
+    <f:entry title="Aqua Scanner path" field="scannerPath">
+      <f:textbox default="" />
+    </f:entry>
    </f:radioBlock>
    <f:radioBlock checked="${instance.isLocationType('hosted')}" name="locationType" value="hosted" title="Hosted image" inline="true" help="/plugin/aqua-security-scanner/help-isHosted.html">
       <f:entry title="Image name" field="hostedImage">
@@ -53,5 +59,4 @@
    <f:entry title="Custom flags" field="customFlags">
     <f:textbox />
    </f:entry>
-
 </j:jelly>

--- a/src/main/webapp/help-containerRuntime.html
+++ b/src/main/webapp/help-containerRuntime.html
@@ -1,0 +1,4 @@
+<div>
+    If skipped, docker will be considered as default runtime.
+    For custom container runtime please provide path of scannercli binary. format: /absolute/location/of/scannerbinary
+</div>


### PR DESCRIPTION

<!-- Please describe your pull request here. -->
1. Container runtime(default: docker): supports container runtime switch for podman and docker
2. Aqua Scanner Path: Path to the executable scanner binary 
https://scalock.atlassian.net/browse/SLK-36824

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x ] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
