### PR TITLE
Make localToken an optional field which accepts string value in pipeline syntax

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>aqua-security-scanner-3.2.0-SNAPSHOT</tag>
+    <tag>aqua-security-scanner-3.2.1-SNAPSHOT</tag>
   </scm>
 
   <build>

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
@@ -49,7 +49,6 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 	private final boolean hideBase;
 	private final boolean showNegligible;
 	private final String policies;
-	private final Secret localToken;
 	private final String customFlags;
 
 	@CheckForNull
@@ -60,6 +59,9 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 
 	@CheckForNull
 	private String tarFilePath;
+
+	@CheckForNull
+	private Secret localToken;
 
 	private static int count;
 	private static int buildId = 0;
@@ -141,6 +143,7 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 		return policies;
 	}
 
+	@CheckForNull
 	public Secret getLocalToken() {
 		return localToken;
 	}
@@ -193,6 +196,11 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 	@DataBoundSetter
 	public void setTarFilePath(@CheckForNull String tarFilePath) {
 		this.tarFilePath = Util.fixNull(tarFilePath);
+	}
+
+	@DataBoundSetter
+	public void setLocalToken(@CheckForNull Secret localToken) {
+		this.localToken = Secret.fromString(Util.fixNull(Secret.toString(localToken)));
 	}
 
 	@Override

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -48,6 +48,9 @@ public class ScannerExecuter {
 			if(scannerPath == null){
 				scannerPath = "";
 			}
+			if(localToken == null){
+				localToken = Secret.fromString("");
+			}
 
 			boolean isDocker = false;
 			if("".equals(containerRuntime) || "docker".equals(containerRuntime)) {

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -133,10 +133,11 @@ public class ScannerExecuter {
 			}else{
 				// Authentication, local token is priority
 				if(!Secret.toString(token).equals("")) {
-					listener.getLogger().println("Received global token, will override global username auth");
+					listener.getLogger().println("Received global token");
 					args.add("--token");
 					args.addMasked(token);
 				} else {
+					listener.getLogger().println("Received global username password auth");
 					args.add("--user", user, "--password");
 					args.addMasked(password);
 				}

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -28,7 +28,7 @@ public class ScannerExecuter {
 			String aquaScannerImage, String apiURL, String user, Secret password, Secret token, int timeout,
 			String runOptions, String locationType, String localImage, String registry, boolean register, String hostedImage,
 			boolean hideBase, boolean showNegligible, boolean checkonly, String notCompliesCmd, boolean caCertificates,
-			String policies, Secret localToken, String customFlags, String tarFilePath, String containerRuntime, String scannerPath) {
+			String policies, Secret localTokenSecret, String customFlags, String tarFilePath, String containerRuntime, String scannerPath) {
 
 		PrintStream print_stream = null;
 		try {
@@ -48,8 +48,8 @@ public class ScannerExecuter {
 			if(scannerPath == null){
 				scannerPath = "";
 			}
-			if(localToken == null){
-				localToken = Secret.fromString("");
+			if(localTokenSecret == null){
+				localTokenSecret = Secret.fromString("");
 			}
 
 			boolean isDocker = false;
@@ -126,10 +126,10 @@ public class ScannerExecuter {
 				args.add("--policies", policies);
 			}
 
-			if (localToken != null && !Secret.toString(localToken).equals("")){
+			if (localTokenSecret != null && !Secret.toString(localTokenSecret).equals("")){
 				listener.getLogger().println("Received local token, will override global auth");
 				args.add("--token");
-				args.addMasked(localToken);
+				args.addMasked(localTokenSecret);
 			}else{
 				// Authentication, local token is priority
 				if(!Secret.toString(token).equals("")) {

--- a/version.md
+++ b/version.md
@@ -6,6 +6,10 @@ registries, for security vulnerabilities, using the API provided by
 
 ## Changelog:
 
+#### **Version 3.2.1 (Feb 25, 2022)**
+
+-   Made localToken an optional field which accepts string value in pipeline syntax 
+
 #### **Version 3.2 (Jan 19, 2022)**
 
 -   Added support of aqua scanner token for authentication at the global and job level settings.


### PR DESCRIPTION
Fix to make localToken an optional field that the user can provide if they want token based authentication at job level.
Previously it was a required field that affected backward compatibility.

Also - updated the configuration to accept a string value in the localToken field in pipeline script. This will remove the requirement to typecast the token into a hudson.util.Secret type in pipeline syntax.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

