### PR TITLE
Added support for hidebase for all scan types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.43</version>
+    <version>4.0</version>
     <relativePath />
   </parent>
   <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -73,9 +73,6 @@ public class ScannerExecuter {
 					"--host", apiURL, "--registry", registry,
 						hostedImage);				
 
-				if (hideBase) {
-					args.add("--hide-base");
-				}
 				if (register) {
 					args.add("--register");
 				}
@@ -125,7 +122,9 @@ public class ScannerExecuter {
 			if (policies != null && !policies.equals("")) {
 				args.add("--policies", policies);
 			}
-
+            if (hideBase) {
+                args.add("--hide-base");
+            }
 			if (localTokenSecret != null && !Secret.toString(localTokenSecret).equals("")){
 				listener.getLogger().println("Received local token, will override global auth");
 				args.add("--token");

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
@@ -35,15 +35,15 @@
       <f:entry title="Image name" field="hostedImage">
 	<f:textbox />
       </f:entry>
-      <f:entry title="Hide base image vulnerabilities" field="hideBase">
-		<f:checkbox name="hideBase"/>
-      </f:entry>
    </f:radioBlock>
    <f:radioBlock checked="${instance.isLocationType('dockerarchive')}" name="locationType" value="dockerarchive" title="docker-archive" inline="true" help="/plugin/aqua-security-scanner/help-isdockerarchive.html">
      <f:entry title="Tar file path" field="tarFilePath" help="/plugin/aqua-security-scanner/help-buildFails.html">
    	   <f:textbox />
      </f:entry>
    </f:radioBlock>
+   <f:entry title="Hide base image vulnerabilities" field="hideBase">
+    <f:checkbox name="hideBase"/>
+   </f:entry>
    <f:entry title="Show negligible vulnerabilities" field="showNegligible">
      <f:checkbox name="showNegligible"/>
    </f:entry>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
**Changes Introduced** 

https://scalock.atlassian.net/browse/SLK-80761
1. Added changes to support hidebase flag for all scan types.
2. Made UI change to make the hidebase option generic and not just specific to hosted image.

### Testing done

Changes has been verified by deploying the .hpi file to the jenkins portal.
**UI changes** 

ORIGINAL UI
![original](https://github.com/user-attachments/assets/6086632e-61d6-4bf0-a019-898683f9b366)

NEW UI
![New](https://github.com/user-attachments/assets/6ea9766f-43e5-416c-a230-eada3aaade23)

### Testing
By deploying the generated .hpi file on jenkins plugin page, we verified the changes.
1. This change added --hidebase flag to the docker command. We verified that the hide base vulnerabilities are being hidden.
```docker run -e BUILD_JOB_NAME=apple-hide-base-local-image -e BUILD_URL=http://3.101.20.171:8080/job/apple-hide-base-local-image/30/ -e BUILD_NUMBER=30 --rm -v /var/run/docker.sock:/var/run/docker.sock aquadev.azurecr.io/scanner:2022.4.557 scan --host http://54.241.149.217:8080/ --local rish007/test:38467 --hide-base --checkonly --no-verify --user administrator --password ****** --html```
3. Earlier the flag was not getting registered for local scan and thus the hide base vulnerabilities were being shown.

Refer to https://scalock.atlassian.net/browse/SLK-80761 for more details

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

