### PR TITLE
Regex removal which breaks HTML rendering

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -228,9 +228,7 @@ public class ScannerExecuter {
 		if (htmlStart < htmlEnd){
 			scanOutput = scanOutput.substring(htmlStart,htmlEnd);
 		} 
-		
-		String scanRegex = "(?m)\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01]).*";
-		scanOutput = scanOutput.replaceAll(scanRegex, "");
+
 		try
 		{
 			target.write(scanOutput, "UTF-8");

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -73,9 +73,6 @@ public class ScannerExecuter {
 					"--host", apiURL, "--registry", registry,
 						hostedImage);				
 
-				if (hideBase) {
-					args.add("--hide-base");
-				}
 				if (register) {
 					args.add("--register");
 				}
@@ -125,7 +122,9 @@ public class ScannerExecuter {
 			if (policies != null && !policies.equals("")) {
 				args.add("--policies", policies);
 			}
-
+            if (hideBase) {
+                args.add("--hide-base");
+            }
 			if (localTokenSecret != null && !Secret.toString(localTokenSecret).equals("")){
 				listener.getLogger().println("Received local token, will override global auth");
 				args.add("--token");

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
@@ -35,15 +35,15 @@
       <f:entry title="Image name" field="hostedImage">
 	<f:textbox />
       </f:entry>
-      <f:entry title="Hide base image vulnerabilities" field="hideBase">
-		<f:checkbox name="hideBase"/>
-      </f:entry>
    </f:radioBlock>
    <f:radioBlock checked="${instance.isLocationType('dockerarchive')}" name="locationType" value="dockerarchive" title="docker-archive" inline="true" help="/plugin/aqua-security-scanner/help-isdockerarchive.html">
      <f:entry title="Tar file path" field="tarFilePath" help="/plugin/aqua-security-scanner/help-buildFails.html">
    	   <f:textbox />
      </f:entry>
    </f:radioBlock>
+   <f:entry title="Hide base image vulnerabilities" field="hideBase">
+    <f:checkbox name="hideBase"/>
+   </f:entry>
    <f:entry title="Show negligible vulnerabilities" field="showNegligible">
      <f:checkbox name="showNegligible"/>
    </f:entry>


### PR DESCRIPTION
The following change introduced a regex - (https://github.com/jenkinsci/aqua-security-scanner-plugin/pull/27) which is causing breaking changes in the HTML rendering logic.

The regex basically matches the generated HTML with the regex and if it matches, it removes the remaining portion of the string from where the regex was matched.  This deletes some closing HTML tags also alongwith any data apart from the matched string, due to which either the HTML is not rendering and has missing content.

Corresponding ticket - https://scalock.atlassian.net/browse/SLK-85072

### Testing done
Removed the regex and verified HTML file generation by deploying the plugin .hpi file to jenkins and triggering a build.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
