### PR TITLE
Adding changes to support rootless podman container image scanning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,12 @@
   </licenses>
   <dependencies>
     <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.30</version> <!-- Use the latest stable version -->
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.26</version>

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -1,9 +1,7 @@
 package org.jenkinsci.plugins.aquadockerscannerbuildstep;
 
 import hudson.*;
-import hudson.Launcher.ProcStarter;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
+import hudson.Launcher;
 import hudson.util.ArgumentListBuilder;
 import java.io.File;
 import java.io.PrintStream;
@@ -16,19 +14,26 @@ import jenkins.model.Jenkins;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
 
 /**
- * This class does the actual execution..
+ * This class does the actual execution.
  *
  * @author Oran Moshai
  */
 public class ScannerExecuter {
+	public static final String PODMAN_SOCKET_SUFFIX = "/podman/podman.sock";
+	public enum ImageLocation {
+		HOSTED,
+		LOCAL,
+		DOCKER_ARCHIVE
+	}
 
 	public static int execute(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener, String artifactName,
 			String aquaScannerImage, String apiURL, String user, Secret password, Secret token, int timeout,
 			String runOptions, String locationType, String localImage, String registry, boolean register, String hostedImage,
 			boolean hideBase, boolean showNegligible, boolean checkonly, String notCompliesCmd, boolean caCertificates,
-			String policies, Secret localTokenSecret, String customFlags, String tarFilePath, String containerRuntime, String scannerPath) {
+			String policies, Secret localTokenSecret, String customFlags, String tarFilePath, String containerRuntime, String scannerPath, String runtimeDirectory) {
 
 		PrintStream print_stream = null;
 		try {
@@ -53,47 +58,86 @@ public class ScannerExecuter {
 			}
 
 			boolean isDocker = false;
-			if("".equals(containerRuntime) || "docker".equals(containerRuntime)) {
+			if(containerRuntime.isEmpty() || "docker".equals(containerRuntime)) {
 				containerRuntime = "docker";
 				isDocker = true;
 			}
-			args.add(containerRuntime);
+			boolean toScanImageWithPodman = !isDocker && !runtimeDirectory.isEmpty();
+
+            args.add(containerRuntime);
 			args.add("run");
+
+			String podmanSocketString = "";
+			if (!isDocker) {
+				/*
+				* If customer provides XDG_RUNTIME_DIR, we are enabling image scan
+				* using rootless podman container else we do file system scan
+				* Refer - https://docs.aquasec.com/saas/image-and-function-scanning/scanning-manually-with-cli/scanner-cli-scan-command/scanner-cli-command-syntax/
+				* */
+				if(!runtimeDirectory.isEmpty()) {
+					String podmanSocket = runtimeDirectory + PODMAN_SOCKET_SUFFIX;
+					podmanSocketString = podmanSocket + ":" + podmanSocket;
+					args.addTokenized("-e XDG_RUNTIME_DIR=" + runtimeDirectory);
+					args.add("--security-opt");
+					args.addTokenized("label=" + "disable");
+				}
+			}
 
 			String buildJobName = env.get("JOB_NAME").trim();
 			buildJobName = buildJobName.replaceAll("\\s+", "");
 			String buildUrl = env.get("BUILD_URL");
 			String buildNumber = env.get("BUILD_NUMBER");
 			args.addTokenized("-e BUILD_JOB_NAME="+buildJobName+" -e BUILD_URL="+buildUrl+" -e BUILD_NUMBER="+buildNumber);
-			switch (locationType) {
-			case "hosted":
+
+			// If scan is of dockerarchive with podman, we don't support it.
+			ImageLocation location = ImageLocation.valueOf(locationType.toUpperCase());
+			if(Objects.equals(location, ImageLocation.DOCKER_ARCHIVE) && !isDocker) {
+				listener.getLogger().println("Podman is not supported with docker-archive");
+				System.exit(1);
+			}
+
+			switch (location) {
+			case HOSTED:
 				args.addTokenized(runOptions);
 
-				args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "scan",
-					"--host", apiURL, "--registry", registry,
-						hostedImage);				
+				if(isDocker) {
+					args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "scan",
+							"--host", apiURL, "--registry", registry,
+							hostedImage);
+				} else {
+					if (!runtimeDirectory.isEmpty()) {
+						args.add("--rm", "-v", podmanSocketString, aquaScannerImage, "scan",
+								"--host", apiURL, "--registry", registry,
+								hostedImage);
+					}
+				}
 
 				if (register) {
 					args.add("--register");
 				}
 				break;
-			case "local":
-				if(!"".equals(scannerPath) && !isDocker) {
-					args.add("-v", scannerPath+":/aquasec/scannercli:Z", "--entrypoint=/aquasec/scannercli");
+			case LOCAL:
+				listener.getLogger().println("runoptions -> " + runOptions);
+				if(!isDocker && runtimeDirectory.isEmpty()) {
+					args.addTokenized(runOptions);
 				}
-				args.addTokenized(runOptions);
+
 				if(isDocker){
 					args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "scan", "--host", apiURL, "--local", localImage);	
 				} else {
-					args.add("--rm", "-u", "root", localImage, "scan", "--host", apiURL);
-				}	
+					if(!runtimeDirectory.isEmpty()) {
+						args.add("--rm", "-v", podmanSocketString, aquaScannerImage, "scan", "--host", apiURL, "--local", localImage);
+					} else {
+						args.add("--rm", "-u", "root", localImage, "scan", "--host", apiURL);
+					}
+				}
 				
 				if (register) {
 					args.add("--registry", registry);
 					args.add("--register");
 				}
 				break;
-			case "dockerarchive":
+			case DOCKER_ARCHIVE:
 				args.addTokenized(runOptions);
 				
 				// extract file name from path for scan tagging
@@ -119,19 +163,27 @@ public class ScannerExecuter {
 			if (caCertificates) {
 				args.add("--no-verify");
 			}
-			if (policies != null && !policies.equals("")) {
+			if (policies != null && !policies.isEmpty()) {
 				args.add("--policies", policies);
 			}
             if (hideBase) {
                 args.add("--hide-base");
             }
-			if (localTokenSecret != null && !Secret.toString(localTokenSecret).equals("")){
+
+			if(toScanImageWithPodman) {
+				args.addTokenized("--socket=" + "podman");
+			} else if(!isDocker && runtimeDirectory.isEmpty()) {
+				args.add("--image-name", localImage);
+				args.add("--fs-scan", "/");
+			}
+
+			if (localTokenSecret != null && !Secret.toString(localTokenSecret).isEmpty()){
 				listener.getLogger().println("Received local token, will override global auth");
 				args.add("--token");
 				args.addMasked(localTokenSecret);
 			}else{
 				// Authentication, local token is priority
-				if(!Secret.toString(token).equals("")) {
+				if(!Secret.toString(token).isEmpty()) {
 					listener.getLogger().println("Received global token");
 					args.add("--token");
 					args.addMasked(token);
@@ -141,17 +193,11 @@ public class ScannerExecuter {
 					args.addMasked(password);
 				}
 			}
-			if(customFlags != null && !customFlags.equals("")) {				
+			if(customFlags != null && !customFlags.isEmpty()) {
 				args.addTokenized(customFlags);
 			}
 
 			args.add("--html");
-
-			
-			if (!isDocker){
-				args.add("--image-name", localImage);
-				args.add("--fs-scan", "/");
-			}
 
 			File outFile = new File(build.getRootDir(), "out");
 			Launcher.ProcStarter ps = launcher.launch();
@@ -183,7 +229,7 @@ public class ScannerExecuter {
 
 			String scanOutput = target.readToString();
 			cleanBuildOutput(scanOutput, target, listener);
-			// Possibly run a shell command on non compliance
+			// Possibly run a shell command on non-compliance
 			if (exitCode == AquaDockerScannerBuilder.DISALLOWED_CODE && !notCompliesCmd.trim().isEmpty()) {
 				ps = launcher.launch();
 				args = new ArgumentListBuilder();
@@ -210,14 +256,14 @@ public class ScannerExecuter {
 			}
 		}
 	}
+
 	//Read output save HTML and print stderr
-	private static boolean cleanBuildOutput(String scanOutput, FilePath target, TaskListener listener) {
+	private static void cleanBuildOutput(String scanOutput, FilePath target, TaskListener listener) {
 
 		int htmlStart = scanOutput.indexOf("<!DOCTYPE html>");
 		if (htmlStart == -1)
 		{
 			listener.getLogger().println(scanOutput);
-			return false;
 		}
 		listener.getLogger().println(scanOutput.substring(0,htmlStart));
 		int htmlEnd = scanOutput.lastIndexOf("</html>") + 7;
@@ -239,7 +285,5 @@ public class ScannerExecuter {
 		{
 			listener.getLogger().println("Failed to save HTML report.");
 		}
-
-		return true;
 	}
 }

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
@@ -44,6 +44,9 @@
    <f:entry title="Hide base image vulnerabilities" field="hideBase">
     <f:checkbox name="hideBase"/>
    </f:entry>
+    <f:entry title="Runtime Directory (only for podman)" field="runtimeDirectory">
+        <f:textbox default="" />
+    </f:entry>
    <f:entry title="Show negligible vulnerabilities" field="showNegligible">
      <f:checkbox name="showNegligible"/>
    </f:entry>


### PR DESCRIPTION
Adding support for **rootless podman container** to scan images using podman.

With this fix customer can scan images using podman container. To support this we added a new UI field to capture the value of **`XDG_RUNTIME_DIR`**
<img width="1046" alt="Screenshot 2024-09-09 at 5 26 14 PM" src="https://github.com/user-attachments/assets/2d1e054a-6ea3-41a8-83ab-d329fbbb7619">


### Testing
Made changes and deployed the generated .hpi file to jenkins plugin.
Tested for the following scenarios -
1. When the user pass **XDG_RUNTIME_DIR** with container runtime as **PODMAN** which will trigger **image scanning**
2. When the customer does not pass **XDG_RUNTIME_DIR**  with container runtime as **PODMAN** which will trigger **filesystem scanning**.

Sample Build for File System - http://54.153.34.143:8080/job/podman/34/console
Sample Build for Image Scanning - http://54.153.34.143:8080/job/podman/30/console

For more details refer [SLK-85443](https://scalock.atlassian.net/browse/SLK-85443)

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
