### PR TITLE
Adding changes to support rootless podman container image scanning

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
@@ -54,6 +54,7 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 	private final boolean showNegligible;
 	private final String policies;
 	private final String customFlags;
+	private String runtimeDirectory;
 
 	@CheckForNull
 	private String containerRuntime;
@@ -74,7 +75,7 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 	@DataBoundConstructor
 	public AquaDockerScannerBuilder(String locationType, String registry, boolean register, String localImage, String hostedImage,
 			String onDisallowed, String notCompliesCmd,  boolean hideBase, boolean showNegligible, String policies, String localToken,
-			String customFlags,	String tarFilePath, String containerRuntime, String scannerPath) {
+			String customFlags,	String tarFilePath, String containerRuntime, String scannerPath, String runtimeDirectory) {
 		this.locationType = locationType;
 		this.registry = registry;
 		this.register = register;
@@ -91,6 +92,7 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 		this.containerRuntime = containerRuntime;
 		this.scannerPath = scannerPath;
 		this.localTokenSecret = hudson.util.Secret.fromString(localToken);
+		this.runtimeDirectory = runtimeDirectory;
 	}
 
 	/**
@@ -156,6 +158,10 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 		return showNegligible;
 	}
 
+	public String getRuntimeDirectory() {
+		return runtimeDirectory;
+	}
+
 	@CheckForNull
 	public String getTarFilePath() { return tarFilePath; }
 
@@ -197,6 +203,11 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 	@DataBoundSetter
 	public void setLocalToken(@CheckForNull String localToken) {
 		this.localToken = Util.fixNull(localToken);
+	}
+
+	@DataBoundSetter
+	public void setRuntimeDirectory(@CheckForNull String runtimeDirectory) {
+		this.runtimeDirectory = Util.fixNull(runtimeDirectory);
 	}
 
 	@Override
@@ -262,7 +273,7 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 		int exitCode = ScannerExecuter.execute(build, workspace,launcher, listener, artifactName, aquaScannerImage, apiURL, user,
 				password, token, timeout, runOptions, locationType, localImage, registry, register, hostedImage, hideBase,
 				showNegligible, onDisallowed == null || !onDisallowed.equals("fail"), notCompliesCmd, caCertificates,
-				policies, localTokenSecret, customFlags, tarFilePath, containerRuntime, scannerPath);
+				policies, localTokenSecret, customFlags, tarFilePath, containerRuntime, scannerPath, runtimeDirectory);
 		build.addAction(new AquaScannerAction(build, artifactSuffix, artifactName, displayImageName));
 
 		archiveArtifacts(build, workspace, launcher, listener);

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -26,7 +26,7 @@ public class ScannerExecuter {
 	public enum ImageLocation {
 		HOSTED,
 		LOCAL,
-		DOCKER_ARCHIVE
+		DOCKERARCHIVE
 	}
 
 	public static int execute(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener, String artifactName,
@@ -91,7 +91,7 @@ public class ScannerExecuter {
 
 			// If scan is of dockerarchive with podman, we don't support it.
 			ImageLocation location = ImageLocation.valueOf(locationType.toUpperCase());
-			if(Objects.equals(location, ImageLocation.DOCKER_ARCHIVE) && !isDocker) {
+			if(Objects.equals(location, I"dockerarchive".equals("dockerarchive") && !isDocker) {
 				listener.getLogger().println("Podman is not supported with docker-archive");
 				System.exit(1);
 			}				
@@ -126,7 +126,7 @@ public class ScannerExecuter {
 					args.add("--register");
 				}
 				break;
-			case DOCKER_ARCHIVE:
+			case DOCKERARCHIVE:
 				args.addTokenized(runOptions);
 				
 				// extract file name from path for scan tagging

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -1,9 +1,7 @@
 package org.jenkinsci.plugins.aquadockerscannerbuildstep;
 
 import hudson.*;
-import hudson.Launcher.ProcStarter;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
+import hudson.Launcher;
 import hudson.util.ArgumentListBuilder;
 import java.io.File;
 import java.io.PrintStream;
@@ -16,6 +14,7 @@ import jenkins.model.Jenkins;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
 
 /**
  * This class does the actual execution..
@@ -23,12 +22,18 @@ import java.nio.file.Paths;
  * @author Oran Moshai
  */
 public class ScannerExecuter {
+	public static final String PODMAN_SOCKET_SUFFIX = "/podman/podman.sock";
+	public enum ImageLocation {
+		HOSTED,
+		LOCAL,
+		DOCKER_ARCHIVE
+	}
 
 	public static int execute(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener, String artifactName,
 			String aquaScannerImage, String apiURL, String user, Secret password, Secret token, int timeout,
 			String runOptions, String locationType, String localImage, String registry, boolean register, String hostedImage,
 			boolean hideBase, boolean showNegligible, boolean checkonly, String notCompliesCmd, boolean caCertificates,
-			String policies, Secret localTokenSecret, String customFlags, String tarFilePath, String containerRuntime, String scannerPath) {
+			String policies, Secret localTokenSecret, String customFlags, String tarFilePath, String containerRuntime, String scannerPath, String runtimeDirectory) {
 
 		PrintStream print_stream = null;
 		try {
@@ -53,39 +58,67 @@ public class ScannerExecuter {
 			}
 
 			boolean isDocker = false;
-			if("".equals(containerRuntime) || "docker".equals(containerRuntime)) {
+			if(containerRuntime.isEmpty() || "docker".equals(containerRuntime)) {
 				containerRuntime = "docker";
 				isDocker = true;
 			}
+			boolean toScanImageWithPodman = !isDocker && !runtimeDirectory.isEmpty();
+
 			args.add(containerRuntime);
 			args.add("run");
+			
+			String podmanSocketString = "";
+			if (!isDocker) {
+				/*
+				 * If customer provides XDG_RUNTIME_DIR, we are enabling image scan
+				 * using rootless podman container else we do file system scan
+				 * Refer - https://docs.aquasec.com/saas/image-and-function-scanning/scanning-manually-with-cli/scanner-cli-scan-command/scanner-cli-command-syntax/
+				 * */
+				if(!runtimeDirectory.isEmpty()) {
+					String podmanSocket = runtimeDirectory + PODMAN_SOCKET_SUFFIX;
+					podmanSocketString = podmanSocket + ":" + podmanSocket;
+					args.addTokenized("-e XDG_RUNTIME_DIR=" + runtimeDirectory);
+					args.add("--security-opt");
+					args.addTokenized("label=" + "disable");
+				}
+			}
 
 			String buildJobName = env.get("JOB_NAME").trim();
 			buildJobName = buildJobName.replaceAll("\\s+", "");
 			String buildUrl = env.get("BUILD_URL");
 			String buildNumber = env.get("BUILD_NUMBER");
 			args.addTokenized("-e BUILD_JOB_NAME="+buildJobName+" -e BUILD_URL="+buildUrl+" -e BUILD_NUMBER="+buildNumber);
-			switch (locationType) {
-			case "hosted":
+
+			// If scan is of dockerarchive with podman, we don't support it.
+			ImageLocation location = ImageLocation.valueOf(locationType.toUpperCase());
+			if(Objects.equals(location, ImageLocation.DOCKER_ARCHIVE) && !isDocker) {
+				listener.getLogger().println("Podman is not supported with docker-archive");
+				System.exit(1);
+			}				
+
+			switch (location) {
+			case HOSTED:
 				args.addTokenized(runOptions);
-
 				args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "scan",
-					"--host", apiURL, "--registry", registry,
-						hostedImage);				
-
+						"--host", apiURL, "--registry", registry,
+						hostedImage);
 				if (register) {
 					args.add("--register");
 				}
 				break;
-			case "local":
-				if(!"".equals(scannerPath) && !isDocker) {
-					args.add("-v", scannerPath+":/aquasec/scannercli:Z", "--entrypoint=/aquasec/scannercli");
+			case LOCAL:
+				if(!isDocker && runtimeDirectory.isEmpty()) {
+					args.addTokenized(runOptions);
 				}
-				args.addTokenized(runOptions);
+				
 				if(isDocker){
 					args.add("--rm", "-v", "/var/run/docker.sock:/var/run/docker.sock", aquaScannerImage, "scan", "--host", apiURL, "--local", localImage);	
 				} else {
-					args.add("--rm", "-u", "root", localImage, "scan", "--host", apiURL);
+					if(!runtimeDirectory.isEmpty()) {
+						args.add("--rm", "-v", podmanSocketString, aquaScannerImage, "scan", "--host", apiURL, "--local", localImage);
+					} else {
+						args.add("--rm", "-u", "root", localImage, "scan", "--host", apiURL);
+					}
 				}	
 				
 				if (register) {
@@ -93,7 +126,7 @@ public class ScannerExecuter {
 					args.add("--register");
 				}
 				break;
-			case "dockerarchive":
+			case DOCKER_ARCHIVE:
 				args.addTokenized(runOptions);
 				
 				// extract file name from path for scan tagging
@@ -119,19 +152,27 @@ public class ScannerExecuter {
 			if (caCertificates) {
 				args.add("--no-verify");
 			}
-			if (policies != null && !policies.equals("")) {
+			if (policies != null && !policies.isEmpty()) {
 				args.add("--policies", policies);
 			}
             if (hideBase) {
                 args.add("--hide-base");
             }
+
+			if(toScanImageWithPodman) {
+				args.addTokenized("--socket=" + "podman");
+			} else if(!isDocker && runtimeDirectory.isEmpty()) {
+				args.add("--image-name", localImage);
+				args.add("--fs-scan", "/");
+			}
+
 			if (localTokenSecret != null && !Secret.toString(localTokenSecret).equals("")){
 				listener.getLogger().println("Received local token, will override global auth");
 				args.add("--token");
 				args.addMasked(localTokenSecret);
 			}else{
 				// Authentication, local token is priority
-				if(!Secret.toString(token).equals("")) {
+				if(!Secret.toString(token).isEmpty()) {
 					listener.getLogger().println("Received global token");
 					args.add("--token");
 					args.addMasked(token);
@@ -141,17 +182,11 @@ public class ScannerExecuter {
 					args.addMasked(password);
 				}
 			}
-			if(customFlags != null && !customFlags.equals("")) {				
+			if(customFlags != null && !customFlags.isEmpty()) {				
 				args.addTokenized(customFlags);
 			}
 
 			args.add("--html");
-
-			
-			if (!isDocker){
-				args.add("--image-name", localImage);
-				args.add("--fs-scan", "/");
-			}
 
 			File outFile = new File(build.getRootDir(), "out");
 			Launcher.ProcStarter ps = launcher.launch();
@@ -210,14 +245,14 @@ public class ScannerExecuter {
 			}
 		}
 	}
+
 	//Read output save HTML and print stderr
-	private static boolean cleanBuildOutput(String scanOutput, FilePath target, TaskListener listener) {
+	private static void cleanBuildOutput(String scanOutput, FilePath target, TaskListener listener) {
 
 		int htmlStart = scanOutput.indexOf("<!DOCTYPE html>");
 		if (htmlStart == -1)
 		{
 			listener.getLogger().println(scanOutput);
-			return false;
 		}
 		listener.getLogger().println(scanOutput.substring(0,htmlStart));
 		int htmlEnd = scanOutput.lastIndexOf("</html>") + 7;
@@ -237,7 +272,5 @@ public class ScannerExecuter {
 		{
 			listener.getLogger().println("Failed to save HTML report.");
 		}
-
-		return true;
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -91,7 +91,7 @@ public class ScannerExecuter {
 
 			// If scan is of dockerarchive with podman, we don't support it.
 			ImageLocation location = ImageLocation.valueOf(locationType.toUpperCase());
-			if(Objects.equals(location, I"dockerarchive".equals("dockerarchive") && !isDocker) {
+			if(Objects.equals(location, ImageLocation.DOCKERARCHIVE) && !isDocker) {
 				listener.getLogger().println("Podman is not supported with docker-archive");
 				System.exit(1);
 			}				

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
@@ -50,6 +50,9 @@
     <f:entry title="Register" field="register">
      <f:checkbox name="register"/>
     </f:entry>
+    <f:entry title="Podman socket directory (applicable to non-root users)" field="runtimeDirectory">
+        <f:textbox default=""  />
+    </f:entry>
    <f:entry title="Registry" field="registry">
      <f:textbox />
    </f:entry>


### PR DESCRIPTION
Adding support for rootless podman container to scan images using podman.

With this fix customer can scan images using podman container. To support this we added a new UI field to capture the value of XDG_RUNTIME_DIR

Screenshot 2024-09-11 at 9 20 13 AM
Testing
Made changes and deployed the generated .hpi file to jenkins plugin.
Tested for the following scenarios -

When the user pass XDG_RUNTIME_DIR with container runtime as PODMAN which will trigger image scanning
When the customer does not pass XDG_RUNTIME_DIR with container runtime as PODMAN which will trigger filesystem scanning.
Sample Build for File System (Podman) - http://54.153.34.143:8080/job/podman/66/console
Sample Build for Image Scanning (Podman) - http://54.153.34.143:8080/job/podman/68/console
Sample Build for Image Scanning (Docker) - http://54.153.34.143:8080/job/podman/65/console

For more details refer [SLK-85443](https://scalock.atlassian.net/browse/SLK-85443)

Tested Scenarios

Container - Podman | Type - FileSystem Scan (runOptions provided) (local)
Container - Podman | Type - Image Scanning (runOptions provided) (local)
Container - Docker | Type - Image Scanning (local)
Tested with few different flags
Submitter checklist
 -> Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch!
 -> Ensure that the pull request title represents the desired changelog entry
 -> Please describe what you did
 -> Link to relevant issues in GitHub or Jira
 -> Link to relevant pull requests, esp. upstream and downstream changes
 -> Ensure you have provided tests - that demonstrates feature works or fixes the issue