### PR TITLE
added authentication fields for scanner image registry login within pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>aqua-security-scanner-3.2.7-SNAPSHOT</tag>
+    <tag>aqua-security-scanner-3.2.8-SNAPSHOT</tag>
   </scm>
 
   <build>

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
@@ -92,7 +92,7 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 		this.containerRuntime = containerRuntime;
 		this.scannerPath = scannerPath;
 		this.localTokenSecret = hudson.util.Secret.fromString(localToken);
-		this.runtimeDirectory = runtimeDirectory;
+		this.runtimeDirectory = Util.fixNull(runtimeDirectory);
 	}
 
 	/**

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
@@ -272,7 +272,10 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 			default:
 				displayImageName = "";	
 		}
-		if (registryAuthType != null && registryAuthType.equals("pipelineAuth")) {
+		if (
+				registryAuthType != null && registryAuthType.equals("pipelineAuth")
+				&& (containerRuntime == null || containerRuntime.isEmpty() || containerRuntime.equals("docker") || containerRuntime.equals("podman"))
+		) {
 			boolean loginSuccess = new AquaScannerRegistryLogin(launcher, listener)
 					.checkAndPerformRegistryLogin(containerRuntime, aquaScannerImage, registryUsername, registryPassword);
 			if (!loginSuccess) {

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder.java
@@ -222,6 +222,7 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 		String user = getDescriptor().getUser();
 		Secret password = getDescriptor().getPassword();
 		Secret token = getDescriptor().getToken();
+		String registryAuthType = getDescriptor().getRegistryAuthType();
 
 		// If user and password is empty, check if token is provided as global or local value
 		if(("").equals(user) && Secret.toString(password).equals("") && 
@@ -271,10 +272,12 @@ public class AquaDockerScannerBuilder extends Builder implements SimpleBuildStep
 			default:
 				displayImageName = "";	
 		}
-		boolean loginSuccess = new AquaScannerRegistryLogin(launcher, listener)
-				.checkAndPerformRegistryLogin(containerRuntime, aquaScannerImage, registryUsername, registryPassword);
-		if (!loginSuccess) {
-			throw new AbortException("Registry login failed.");
+		if (registryAuthType != null && registryAuthType.equals("pipelineAuth")) {
+			boolean loginSuccess = new AquaScannerRegistryLogin(launcher, listener)
+					.checkAndPerformRegistryLogin(containerRuntime, aquaScannerImage, registryUsername, registryPassword);
+			if (!loginSuccess) {
+				throw new AbortException("Registry login failed.");
+			}
 		}
 		int exitCode = ScannerExecuter.execute(build, workspace,launcher, listener, artifactName, aquaScannerImage, apiURL, user,
 				password, token, timeout, runOptions, locationType, localImage, registry, register, hostedImage, hideBase,

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaScannerRegistryLogin.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaScannerRegistryLogin.java
@@ -1,0 +1,94 @@
+package org.jenkinsci.plugins.aquadockerscannerbuildstep;
+
+import hudson.Launcher;
+import hudson.model.TaskListener;
+import hudson.util.ArgumentListBuilder;
+import hudson.util.Secret;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+public class AquaScannerRegistryLogin {
+    private Launcher launcher;
+    private TaskListener listener;
+    private int loginAttempts;
+
+    public AquaScannerRegistryLogin(Launcher launcher, TaskListener listener) {
+        this.launcher = launcher;
+        this.listener = listener;
+    }
+
+
+    public boolean checkAndPerformRegistryLogin(String containerRuntime, String imageName, String username, Secret password) {
+        Launcher.ProcStarter ps = launcher.launch();
+        ArgumentListBuilder args = new ArgumentListBuilder();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        args.add(containerRuntime != null && containerRuntime.equals("podman") ? "podman" : "docker");
+        args.add("inspect", "--format='{{.RepoTags}}'", imageName);
+        ps.cmds(args).stdin(null).stderr(outputStream).stdout(outputStream);
+        try {
+            int exitCode = ps.join(); // RUN !
+            String result = outputStream.toString(StandardCharsets.UTF_8.name()).trim();
+
+            if (exitCode == 0 && !result.isEmpty()) {
+                // result is non-empty and exitCode is 0 indicates that image inspect worked fine, so should return loginStatus:true
+                return true;
+            } else if (!username.isEmpty()) {
+                // non-empty username indicates that credentials are configured for scanner-registry at jenkins-system-config.
+                // action: perform docker-login with credentials and return as loginStatus.
+                return registryLogin(containerRuntime, getRegistryName(imageName), username, password, 1);
+            } else {
+                // If none of above conditions match, return loginStatus: true which will not block existing behaviour
+                // As backward compatibility, we should allow this case.
+                return true;
+            }
+        } catch (Exception e) {
+            listener.getLogger().println(e.toString());
+            return false;
+        }
+    }
+
+    private boolean registryLogin(String containerRuntime, String registryName, String userName, Secret password, int retries) {
+        loginAttempts += 1;
+        if (loginAttempts > retries) {
+            return false;
+        }
+        Launcher.ProcStarter ps = launcher.launch();
+        ArgumentListBuilder args = new ArgumentListBuilder();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        args.add(containerRuntime != null && containerRuntime.equals("podman") ? "podman" : "docker");
+        args.add("login", registryName);
+        args.add("-u").addMasked(userName);
+        args.add("--password-stdin");
+        ps.cmds(args).stdin(new ByteArrayInputStream((password.getPlainText() + "\n").getBytes(StandardCharsets.UTF_8)))
+                        .stderr(outputStream).stdout(outputStream);
+        try {
+            int exitCode = ps.join(); // RUN !
+            String result = outputStream.toString(StandardCharsets.UTF_8.name()).trim();
+            if (exitCode != 0) {
+                listener.getLogger().println("Authentication failed: incorrect credentials provided. Please provide valid registry credentials.");
+                listener.getLogger().println(result);
+                return false;
+            } else {
+                listener.getLogger().println("Authenticated with registry successfully.");
+                return true;
+            }
+        } catch (Exception e) {
+            listener.getLogger().println("Failed registry login: " + e.toString());
+            return registryLogin(containerRuntime, registryName, userName, password, retries);
+        }
+    }
+
+    private static String getRegistryName(String imageName) {
+        // Check if the image name contains a registry (identified by the presence of '/')
+        if (imageName.contains("/")) {
+            String[] parts = imageName.split("/", 2); // Split the image name into registry/repository
+            // If the first part contains a dot (.) or a colon (:), it's a registry name
+            if (parts[0].contains(".") || parts[0].contains(":")) {
+                return parts[0];
+            }
+        }
+        return "docker.io";
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
@@ -7,11 +7,11 @@
   -->
 
    <f:block>
-     <b>When image doesn’t comply with Aqua policy:</b>
+     <b>When an image does not comply with Aqua Image Assurance Policies:</b>
    </f:block>
    <f:radioBlock checked="${instance.isOnDisallowed('ignore') or true}" name="onDisallowed" value="ignore" title="Never fail builds" inline="true" help="/plugin/aqua-security-scanner/help-logAndIgnore.html">
    </f:radioBlock>
-   <f:radioBlock checked="${instance.isOnDisallowed('fail')}" name="onDisallowed" value="fail" title="Perform the action defined in Aqua’s policy" inline="true" help="/plugin/aqua-security-scanner/help-buildFails.html">
+   <f:radioBlock checked="${instance.isOnDisallowed('fail')}" name="onDisallowed" value="fail" title="Perform the action defined in Aqua Image Assurance Policies" inline="true" help="/plugin/aqua-security-scanner/help-aquaImageAssurancePolicies.html">
       <f:entry title="Shell command to execute when no compliance" field="notCompliesCmd">
 	<f:textbox />
       </f:entry>
@@ -37,7 +37,7 @@
       </f:entry>
    </f:radioBlock>
    <f:radioBlock checked="${instance.isLocationType('dockerarchive')}" name="locationType" value="dockerarchive" title="docker-archive" inline="true" help="/plugin/aqua-security-scanner/help-isdockerarchive.html">
-     <f:entry title="Tar file path" field="tarFilePath" help="/plugin/aqua-security-scanner/help-buildFails.html">
+     <f:entry title="Tar file path" field="tarFilePath">
    	   <f:textbox />
      </f:entry>
    </f:radioBlock>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/global.jelly
@@ -8,11 +8,11 @@
     <f:entry title="Aqua scanner image" field="aquaScannerImage">
       <f:textbox />
     </f:entry>
-    <f:radioBlock checked="${instance.isRegistryAuthType('manualAuth') or true}" name="registryAuth" value="manualAuth" title="Manual authentication">
+    <f:radioBlock checked="${instance.isRegistryAuthType('manualAuth') or true}" name="registryAuth" value="manualAuth" title="Manual authentication to the registry hosting scanner image"  help="/plugin/aqua-security-scanner/help-registryManualAuthentication.html">
     </f:radioBlock>
-    <f:radioBlock checked="${instance.isRegistryAuthType('pipelineAuth')}" name="registryAuth" value="pipelineAuth" title="Username/Password for authentication">
+    <f:radioBlock checked="${instance.isRegistryAuthType('pipelineAuth')}" name="registryAuth" value="pipelineAuth" title="Username/Password for authentication to the registry hosting scanner image">
       <f:nested>
-        <f:entry title="User" field="registryUsername">
+        <f:entry title="Username" field="registryUsername">
           <f:textbox />
         </f:entry>
         <f:entry title="Password" field="registryPassword">
@@ -20,12 +20,12 @@
         </f:entry>
       </f:nested>
     </f:radioBlock>
-    <f:entry title="Aqua API URL" field="apiURL">
+    <f:entry title="Aqua Server URL" field="apiURL">
       <f:textbox />
     </f:entry>
-    <f:radioBlock checked="${instance.isAuthType('uname') or true}" name="auth" value="uname" title="Username/Password for authentication">
+    <f:radioBlock checked="${instance.isAuthType('uname') or true}" name="auth" value="uname" title="Username/Password for authentication to the Aqua Server">
      <f:nested>
-        <f:entry title="User" field="user">
+        <f:entry title="Username" field="user">
           <f:textbox />
         </f:entry>
         <f:entry title="Password" field="password">
@@ -33,7 +33,7 @@
         </f:entry>
       </f:nested>
     </f:radioBlock>
-    <f:radioBlock checked="${instance.isAuthType('token')}" name="auth" value="token" title="Token for authentication">
+    <f:radioBlock checked="${instance.isAuthType('token')}" name="auth" value="token" title="Token for authentication to the Aqua Server">
       <f:nested>
         <f:entry title="Token" field="token">
           <f:password />

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/global.jelly
@@ -8,6 +8,18 @@
     <f:entry title="Aqua scanner image" field="aquaScannerImage">
       <f:textbox />
     </f:entry>
+    <f:radioBlock checked="${instance.isRegistryAuthType('manualAuth') or true}" name="registryAuth" value="manualAuth" title="Manual authentication">
+    </f:radioBlock>
+    <f:radioBlock checked="${instance.isRegistryAuthType('pipelineAuth')}" name="registryAuth" value="pipelineAuth" title="Username/Password for authentication">
+      <f:nested>
+        <f:entry title="User" field="registryUsername">
+          <f:textbox />
+        </f:entry>
+        <f:entry title="Password" field="registryPassword">
+          <f:password />
+        </f:entry>
+      </f:nested>
+    </f:radioBlock>
     <f:entry title="Aqua API URL" field="apiURL">
       <f:textbox />
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-apiURL.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-apiURL.html
@@ -1,3 +1,0 @@
-<div>
-  The url prefix used for Aqua API endpoints.
-</div>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-aquaScannerImage.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-aquaScannerImage.html
@@ -1,5 +1,6 @@
 <div>
-  The full name of the Aqua scanner image, including tag, e.g. registry.aquasec.com/scanner:4.5<br>
-  You need to pull this image using "<code>docker pull registry.aquasec.com/scanner:4.5</code>" on the Jenkins server node.<br>
-  Since this is a private image, you need to be authorized by Aqua Security to do this.
+  Specify the name of the scanner image including the registry URL, image name, and tag (e.g. <code>&lt;registry-url&gt;/&lt;image-name&gt;:&lt;tag&gt;</code>).
+  <br>
+  This registry is private and requires authentication. You can authenticate manually or provide your credentials in the fields below.
 </div>
+

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-localImage.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-localImage.html
@@ -1,3 +1,3 @@
 <div>
-Path of local Docker image, including tag. E.g. <i>my_ubuntu:latest</i>
+    Enter the local image name
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-localToken.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-localToken.html
@@ -1,5 +1,4 @@
 <div>
-    Scanner Token for Aqua API. 
-    * This token will override the Global Token/Username-Password.
-    * Scanner token entered here is applied at job level. User can use a different token for different builds.
+    This token overrides the global token or Username/Password authentication.
+    The token entered here applies to this pipeline job, allowing different tokens for different builds.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-password.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-password.html
@@ -1,3 +1,3 @@
 <div>
-  Password for Aqua API.
+  Password for authentication to the Aqua Server
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-policies.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-policies.html
@@ -1,3 +1,3 @@
 <div>
-Comma separated names of image assurance policies. Available for only for local images and with scanner cli > v3.2.
+    Comma-separated names of Image Assurance Policies
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-registry.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-registry.html
@@ -1,3 +1,3 @@
 <div>
-Name of a Docker registry that is defined in the Aqua Management Console. E.g. <i>Docker Hub</i>.
+    Name of the registry that is already integrated with Aqua
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-registryPassword.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-registryPassword.html
@@ -1,0 +1,3 @@
+<div>
+  Registry password for authentication to retrieve the scanner image.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-registryPassword.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-registryPassword.html
@@ -1,3 +1,3 @@
 <div>
-  Registry password for authentication to retrieve the scanner image.
+  Password for authentication to the Aqua registry to retrieve the scanner image
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-registryUsername.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-registryUsername.html
@@ -1,3 +1,3 @@
 <div>
-  Registry username for authentication to retrieve the scanner image.
+  Username for authentication to the Aqua registry to retrieve the scanner image
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-registryUsername.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-registryUsername.html
@@ -1,0 +1,3 @@
+<div>
+  Registry username for authentication to retrieve the scanner image.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-runOptions.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-runOptions.html
@@ -1,3 +1,3 @@
 <div>
-  Additional options to be applier to Docker's run command, when used to run the Aqua scanner.
+  Additional options to apply to Docker run command when executing the Aqua scanner
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-tarFilePath.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-tarFilePath.html
@@ -1,0 +1,3 @@
+<div>
+    Enter absolute path to the TAR file, e.g., docker save -o &lt;path&gt; &lt;image_name&gt;.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-tarfilepath.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-tarfilepath.html
@@ -1,3 +1,0 @@
-<div>
-Should provide the relative path of tar file to scan.
-</div>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-token.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-token.html
@@ -1,5 +1,7 @@
 <div>
-    Scanner Token for Aqua API. 
-    * This token will override the User and Password field values.
-    * Scanner token entered here is applied for all the Jobs configured in Jenkins. This token can be overridden with another at the Job configuration.
+    Scanner Token for Aqua API.
+    <ul style="list-style-type: circle;">
+        <li>This token will override the User and Password field values.</li>
+        <li>Scanner token entered here is applied for all the Jobs configured in Jenkins. This token can be overridden with another at the Job configuration.</li>
+    </ul>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-user.html
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/help-user.html
@@ -1,3 +1,3 @@
 <div>
-  User name for Aqua API.
+  Username for authentication to the Aqua Server
 </div>

--- a/src/main/webapp/help-aquaImageAssurancePolicies.html
+++ b/src/main/webapp/help-aquaImageAssurancePolicies.html
@@ -1,0 +1,3 @@
+<div>
+    Fail the Jenkins build or allow it to continue based on the rules defined in Aqua Image Assurance Policies
+</div>

--- a/src/main/webapp/help-buildFails.html
+++ b/src/main/webapp/help-buildFails.html
@@ -1,3 +1,3 @@
 <div>
-The Jenkins build should fail
+    Fail the Jenkins build
 </div>

--- a/src/main/webapp/help-containerRuntime.html
+++ b/src/main/webapp/help-containerRuntime.html
@@ -1,4 +1,5 @@
 <div>
-    If skipped, docker will be considered as default runtime.
-    For custom container runtime please provide path of scannercli binary. format: /absolute/location/of/scannerbinary
+    Supported runtime - Docker and Podman.
+    <br>For any other container runtime, provide absolute path to the scannercli binary in the format: /absolute/location/of/scannerbinary.
+    <br>By default, Docker will be used.
 </div>

--- a/src/main/webapp/help-isHosted.html
+++ b/src/main/webapp/help-isHosted.html
@@ -1,3 +1,3 @@
 <div>
-Scan a Docker image that is hosted on a registry that is defined in the Aqua Management Console.
+    Scan an image from a registry that is already integrated with Aqua
 </div>

--- a/src/main/webapp/help-isLocal.html
+++ b/src/main/webapp/help-isLocal.html
@@ -1,3 +1,3 @@
 <div>
-Scan a Docker image that resides in the local Docker setup.
+    Scan a local image
 </div>

--- a/src/main/webapp/help-isdockerarchive.html
+++ b/src/main/webapp/help-isdockerarchive.html
@@ -1,3 +1,3 @@
 <div>
-Scan docker-archive files which is in tar file format. Provide tar file relative path to scan . E.g. <i>docker save -o path image_name</i>
+    Scan a docker-archive file in TAR format
 </div>

--- a/src/main/webapp/help-logAndIgnore.html
+++ b/src/main/webapp/help-logAndIgnore.html
@@ -1,3 +1,3 @@
 <div>
-Log the non-compliance but continue with no failure.
+    Log non-compliance of images but allow the Jenkins build to continue without failure
 </div>

--- a/src/main/webapp/help-registryManualAuthentication.html
+++ b/src/main/webapp/help-registryManualAuthentication.html
@@ -1,0 +1,3 @@
+<div>
+    Manually authenticate to the registry hosting scanner image
+</div>


### PR DESCRIPTION
## Description

Currently, the Jenkins plugin includes a field for the "Aqua scanner image" but lacks credentials fields.
These fields are necessary for authenticating to the registry from which the scanner image is pulled. By adding these credentials fields, we can automate the authentication process and eliminate the need for manual intervention.

EPIC: [SLK-87624](https://scalock.atlassian.net/browse/SLK-87624)


## Development approach

1. Check if scanner image present locally with image inspect command.
2. If image is present -> proceed with scanning step.
    else -> perform registry login with credentials configured at jenkins global configurations.
3. On successful login -> proceed with scanning step.
    On failed login -> provide error message to user and fail the build.



<!-- Please describe your pull request here. -->

## Testing done

### Manual authentication with docker (backward-compatibility)
- [x] scanner-image present in node + registry-login active
- [x] scanner-image present in node + registry-login inactive
- [x] scanner-image not-present in node + registry-login active
- [x] scanner-image not-present in node + registry-login inactive

### Username/Password authentication with docker (new feature)
- [x] scanner-image present in node + registry-login active
- [x] scanner-image present in node + registry-login inactive
- [x] scanner-image not-present in node + registry-login active
- [x] scanner-image not-present in node + registry-login inactive


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
