### PR TITLE
[SECURITY-3542 / CVE-2025-53653 / SLK-97728] Fix security vulnerability: Encrypt local scanner tokens

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.10</version>
+      <version>3.0.24</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.20</version>
+      <version>1.24</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
+++ b/src/main/java/org/jenkinsci/plugins/aquadockerscannerbuildstep/ScannerExecuter.java
@@ -33,7 +33,7 @@ public class ScannerExecuter {
 			String aquaScannerImage, String apiURL, String user, Secret password, Secret token, int timeout,
 			String runOptions, String locationType, String localImage, String registry, boolean register, String hostedImage,
 			boolean hideBase, boolean showNegligible, boolean checkonly, String notCompliesCmd, boolean caCertificates,
-			String policies, Secret localTokenSecret, String customFlags, String tarFilePath, String containerRuntime, String scannerPath, String runtimeDirectory) {
+			String policies, Secret localToken, String customFlags, String tarFilePath, String containerRuntime, String scannerPath, String runtimeDirectory) {
 
 		PrintStream print_stream = null;
 		try {
@@ -53,8 +53,8 @@ public class ScannerExecuter {
 			if(scannerPath == null){
 				scannerPath = "";
 			}
-			if(localTokenSecret == null){
-				localTokenSecret = Secret.fromString("");
+			if(localToken == null){
+				localToken = Secret.fromString("");
 			}
 
 			boolean isDocker = false;
@@ -170,10 +170,10 @@ public class ScannerExecuter {
 				args.add("--fs-scan", "/");
 			}
 
-			if (localTokenSecret != null && !Secret.toString(localTokenSecret).equals("")){
+			if (localToken != null && !Secret.toString(localToken).equals("")){
 				listener.getLogger().println("Received local token, will override global auth");
 				args.add("--token");
-				args.addMasked(localTokenSecret);
+				args.addMasked(localToken);
 			}else{
 				// Authentication, local token is priority
 				if(!Secret.toString(token).isEmpty()) {

--- a/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/aquadockerscannerbuildstep/AquaDockerScannerBuilder/config.jelly
@@ -62,6 +62,10 @@
    <f:entry title="Token" field="localToken">
     <f:password />
    </f:entry>
+   <!-- This hidden field ensures the token is saved in encrypted format -->
+   <f:invisibleEntry>
+     <input type="hidden" name="_.localTokenForXml" value="${instance.localTokenForXml}" />
+   </f:invisibleEntry>
    <f:entry title="Custom flags" field="customFlags">
     <f:textbox />
    </f:entry>

--- a/version.md
+++ b/version.md
@@ -6,9 +6,40 @@ registries, for security vulnerabilities, using the API provided by
 
 ## Changelog:
 
-#### **Version 3.2.9 (Jul 14, 2025)**
+#### **Version 3.2.9 (July 16, 2025)**
 
-- Resolved an issue where the custom scanner path is not respected during local image scans.
+### Security Fixes
+- **SECURITY-3542 / CVE-2025-53653**: Fixed tokens stored in plain text vulnerability
+  - Local scanner tokens are now properly encrypted using Jenkins' Secret class
+  - Tokens are no longer stored in plain text in job config.xml files
+  - Added backward compatibility for existing configurations
+  - Users with Item/Extended Read permission can no longer view tokens in plain text
+  - Implemented migration approach that automatically encrypts tokens when jobs are loaded or executed
+  - Added XML serialization control to ensure tokens are always saved in encrypted format
+
+### Bug Fixes
+- Fixed an issue where the custom scanner path was not respected during local image scans
+
+### Dependency Security Updates
+- Updated `org.codehaus.plexus:plexus-utils` from 3.0.10 to 3.0.24 to fix:
+  - **CVE-2017-1000487** (CRITICAL): Fixed command injection vulnerability in Commandline class
+  - **CVE-2022-4244** (HIGH): Fixed directory traversal vulnerability
+  - **CVE-2022-4245** (MEDIUM): Fixed XML External Entity (XXE) injection vulnerability
+- Updated `org.jenkins-ci.plugins:structs` to version 1.24 for improved compatibility
+
+### Technical Changes
+- Changed `localToken` field from `String` to `Secret` type
+- Added `readResolve()` method for configuration migration
+- Added custom XML serialization method to ensure tokens are always encrypted
+- Enhanced job execution to detect and migrate plaintext tokens
+- Updated token handling in `ScannerExecuter` class
+- Improved build process with containerized build support
+
+### Migration Notes
+- Existing configurations will be automatically migrated when jobs are loaded or executed
+- No manual intervention required for existing installations
+- Tokens will be re-encrypted on first job execution or configuration save
+- Migration is logged in the Jenkins console for transparency
 
 #### **Version 3.2.8 (Apr 1, 2025)**
 


### PR DESCRIPTION
This commit addresses SECURITY-3542 / CVE-2025-53653 by encrypting local scanner tokens that were previously stored in plaintext.

Key changes:
- Changed the `localToken` field from `String` to the `Secret` type to ensure tokens are always encrypted in memory and on disk.
- Implemented a `readResolve` method to provide backward compatibility, automatically and lazily migrating legacy plaintext tokens to the new encrypted format when a job is loaded.
- Added an invisible form field to ensure the encrypted token is correctly serialized to `config.xml`.
- Updated dependencies `plexus-utils` and `structs` to address downstream vulnerabilities and improve compatibility.

<!-- Please describe your pull request here. -->

### Testing done
[SLK-97728](https://scalock.atlassian.net/browse/SLK-97728?focusedCommentId=501219)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
